### PR TITLE
Update README.md to clarify the meaning of "state_color"

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ preset_buttons:
 | `invert_position_label` | `boolean` | false        | Inverts position label (if `false` => 0% = closed, 100% = open; if `true` => 0% = open, 100% = closed) |
 | `disable_position`| `boolean` | false        | Disables position controls |
 | `rtl_position`    | `boolean` | false        | Switches direction of the position slider to right to left |
-| `state_color`     | `boolean` | false        | Enables icon coloring if entity is active |
+| `state_color`     | `boolean` | false        | Enables icon coloring if the shutter is not fully closed |
 | `group`           | `boolean` | false        | Removes outer card styling, use if card is part of entities card |
 | `title_template`  | [`template`](https://www.home-assistant.io/docs/configuration/templating/) | Optional | Overwrites card title with a rendered template |
 | `position_template`| [`template`](https://www.home-assistant.io/docs/configuration/templating/) | Optional| Overwrites position with a rendered template |


### PR DESCRIPTION
The term "active" is not so intuitive to indicate that the shutter is not fully closed.  Changed the description in README.md to be explicit on the meaning.

Resolving #15